### PR TITLE
chore: Use module from absolute path example

### DIFF
--- a/.github/workflows/module-test.yaml
+++ b/.github/workflows/module-test.yaml
@@ -39,3 +39,8 @@ jobs:
     - name: Use Your Nu Modules
       run: |
         nu -c "use nu/module.nu *; print (get-env 'ABC-XYZ' 'DEFAULT-ABC-XYZ')"
+    - name: Use Your Nu Modules by Absolute Path
+      run: |
+        use ${{ github.workspace }}/nu/module.nu *
+        print 'Use module from: ${{ github.workspace }}/nu/module.nu'
+        print (get-env 'ABC-XYZ' 'DEFAULT-ABC-XYZ-ABSOLUTE-PATH')


### PR DESCRIPTION
chore: Use module from absolute path example