### PR TITLE
chore: Update Nu version in workflows and README files to 0.103

### DIFF
--- a/.github/workflows/latest-matrix.yaml
+++ b/.github/workflows/latest-matrix.yaml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest, ubuntu-22.04, ubuntu-22.04-arm, macos-13, macos-latest]
-        ver: [0.102.0]
+        ver: [0.103.0]
 
     runs-on: ${{ matrix.os }}
     name: test (${{matrix.os}}, nu@${{matrix.ver}})

--- a/.github/workflows/main-matrix.yaml
+++ b/.github/workflows/main-matrix.yaml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest, ubuntu-22.04, ubuntu-22.04-arm, macos-latest]
-        ver: [0.101.0, 0.98.0, 0.97.1, 0.96.1, 0.95.0, 0.93.0, 0.92.2, 0.91.0, 0.90.1]
+        ver: [0.103.0, 0.101.0, 0.98.0, 0.97.1, 0.96.1, 0.95.0, 0.93.0, 0.92.2, 0.91.0, 0.90.1]
 
     runs-on: ${{ matrix.os }}
     name: test (${{matrix.os}}, nu@${{matrix.ver}})

--- a/.github/workflows/module-test.yaml
+++ b/.github/workflows/module-test.yaml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-22.04, macos-latest, windows-latest]
-        ver: [0.101.0, 0.98.0, 0.97.1, 0.96.1, 0.93.0, 0.92.2, 0.91.0, 0.90.1]
+        ver: [0.103.0, 0.101.0, 0.98.0, 0.97.1, 0.96.1, 0.93.0, 0.92.2, 0.91.0, 0.90.1]
 
     runs-on: ${{ matrix.os }}
     name: test (${{matrix.os}}, nu@${{matrix.ver}})

--- a/.github/workflows/release-matrix.yaml
+++ b/.github/workflows/release-matrix.yaml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest, ubuntu-22.04, ubuntu-22.04-arm, macos-latest]
-        ver: [0.101.0, 0.98.0, 0.97.1, 0.96.1, 0.95.0, 0.93.0, 0.92.2, 0.91.0, 0.90.1]
+        ver: [0.103.0, 0.101.0, 0.98.0, 0.97.1, 0.96.1, 0.95.0, 0.93.0, 0.92.2, 0.91.0, 0.90.1]
 
     runs-on: ${{ matrix.os }}
     name: test (${{matrix.os}}, nu@${{matrix.ver}})

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ To use modules in `Nu`, please refer to the following examples:
 - name: Setup nu
   uses: hustcer/setup-nu@v3
   with:
-    version: 0.101.0
+    version: 0.103.0
 - name: Use Your Nu Modules by NU_LIB_DIRS Constant
   shell: nu {0}
   run: |
@@ -87,7 +87,7 @@ To use modules in `Nu`, please refer to the following examples:
 - name: Setup nu
   uses: hustcer/setup-nu@v3
   with:
-    version: 0.101.0
+    version: 0.103.0
   env:
     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 - name: Use Your Nu Modules
@@ -104,7 +104,7 @@ You have to wrap the `nu` code in `nu -c ""`, and the nu version should be equal
 - name: Setup nu
   uses: hustcer/setup-nu@v3
   with:
-    version: 0.101.0
+    version: 0.103.0
   env:
     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 - name: Use Your Nu Modules by Absolute Path

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -67,7 +67,7 @@ jobs:
 - name: Setup nu
   uses: hustcer/setup-nu@v3
   with:
-    version: 0.101.0
+    version: 0.103.0
 - name: Use Your Nu Modules by NU_LIB_DIRS Constant
   shell: nu {0}
   run: |
@@ -83,7 +83,7 @@ jobs:
 - name: Setup nu
   uses: hustcer/setup-nu@v3
   with:
-    version: 0.101.0
+    version: 0.103.0
   env:
     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 - name: Use Your Nu Modules
@@ -100,7 +100,7 @@ jobs:
 - name: Setup nu
   uses: hustcer/setup-nu@v3
   with:
-    version: 0.101.0
+    version: 0.103.0
   env:
     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 - name: Use Your Nu Modules by Absolute Path


### PR DESCRIPTION
chore: Update Nu version in workflows and README files to 0.103

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated setup guides and examples to reference Nushell version 0.103.0.
- **Chores**
  - Enhanced automated testing and release configurations to align with the new Nushell version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->