### PR TITLE
feat: Use public GitHub API for Nushell assets query, try to make it work for GitHub Enterprise

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -55491,7 +55491,8 @@ function getRelease(tool) {
     return __awaiter(this, void 0, void 0, function* () {
         const { owner, name, versionSpec, checkLatest = false, features = 'default' } = tool;
         const isNightly = versionSpec === 'nightly';
-        const octokit = new rest_1.Octokit({ auth: tool.githubToken });
+        // Use public GitHub API for Nushell assets query, make it work for GitHub Enterprise
+        const octokit = new rest_1.Octokit({ auth: tool.githubToken, baseUrl: 'https://api.github.com' });
         return octokit
             .paginate(octokit.repos.listReleases, { owner, repo: name }, (response, done) => {
             const nightlyReleases = isNightly ? filterLatestNightly(response, features) : [];

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -211,7 +211,9 @@ function filterLatestNightly(response: any, features: 'default' | 'full'): Relea
 async function getRelease(tool: Tool): Promise<Release> {
   const { owner, name, versionSpec, checkLatest = false, features = 'default' } = tool;
   const isNightly = versionSpec === 'nightly';
-  const octokit = new Octokit({ auth: tool.githubToken });
+
+  // Use public GitHub API for Nushell assets query, make it work for GitHub Enterprise
+  const octokit = new Octokit({ auth: tool.githubToken, baseUrl: 'https://api.github.com' });
 
   return octokit
     .paginate(octokit.repos.listReleases, { owner, repo: name }, (response, done) => {


### PR DESCRIPTION
feat: Use public GitHub API for Nushell assets query, try to make it work for GitHub Enterprise

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved release retrieval to ensure seamless support for both public GitHub API and GitHub Enterprise configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->