### PR TITLE
deps: Bump actions/checkout to v7

### DIFF
--- a/.github/workflows/basic.yaml
+++ b/.github/workflows/basic.yaml
@@ -16,7 +16,7 @@ jobs:
   basic-usage:
     runs-on: ubuntu-22.04
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
     - uses: hustcer/setup-nu@develop
       with:
         version: '*'
@@ -37,7 +37,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     name: test (${{matrix.os}}, setup-nu@latest-dev)
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
     - name: Setup nu@latest
       uses: hustcer/setup-nu@develop
       with:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -15,7 +15,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
     - uses: actions/setup-node@v6
       with:
         node-version: '24'
@@ -39,7 +39,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     name: test (${{matrix.os}}, ${{ matrix.crate.owner }}/${{ matrix.crate.name }})
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
     - name: Setup ${{ matrix.crate.owner }}/${{ matrix.crate.name }}
       uses: ./
       with:

--- a/.github/workflows/full-matrix.yaml
+++ b/.github/workflows/full-matrix.yaml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     name: test (${{matrix.os}}, nu@${{matrix.ver}})
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
     - name: Setup nu@${{matrix.ver}}
       uses: hustcer/setup-nu@develop
       with:

--- a/.github/workflows/latest-matrix.yaml
+++ b/.github/workflows/latest-matrix.yaml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     name: test (${{matrix.os}}, nu@${{matrix.ver}})
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
     - name: Setup nu@${{matrix.ver}}
       uses: hustcer/setup-nu@v3
       with:

--- a/.github/workflows/main-matrix.yaml
+++ b/.github/workflows/main-matrix.yaml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     name: test (${{matrix.os}}, nu@${{matrix.ver}})
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
     - name: Setup nu@${{matrix.ver}}
       uses: hustcer/setup-nu@main
       with:

--- a/.github/workflows/module-test.yaml
+++ b/.github/workflows/module-test.yaml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     name: test (${{matrix.os}}, nu@${{matrix.ver}})
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
     - name: Setup nu@latest
       uses: hustcer/setup-nu@develop
       with:

--- a/.github/workflows/release-matrix.yaml
+++ b/.github/workflows/release-matrix.yaml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     name: test (${{matrix.os}}, nu@${{matrix.ver}})
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
     - name: Setup nu@${{matrix.ver}}
       uses: hustcer/setup-nu@v3
       with:

--- a/.github/workflows/use-nightly.yaml
+++ b/.github/workflows/use-nightly.yaml
@@ -15,7 +15,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
     - uses: actions/setup-node@v6
       with:
         node-version: '24'
@@ -39,7 +39,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     name: test (${{matrix.os}}, ${{ matrix.crate.owner }}/${{ matrix.crate.name }})
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
     - name: Setup ${{ matrix.crate.owner }}/${{ matrix.crate.name }}
       uses: ./
       with:

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ jobs:
   basic-usage:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: hustcer/setup-nu@main
         with:
           version: "*"

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -44,7 +44,7 @@ jobs:
   basic-usage:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: hustcer/setup-nu@main
         with:
           version: "*"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration workflows to use the latest GitHub Actions checkout tooling across build and test jobs.
* **Documentation**
  * Refreshed the example workflow snippets in the main README and the Chinese README to reference the updated checkout action version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->